### PR TITLE
Allow override of event channel

### DIFF
--- a/man/read_edf.Rd
+++ b/man/read_edf.Rd
@@ -4,12 +4,16 @@
 \alias{read_edf}
 \title{Read an edf/edf+/bdf file into R}
 \usage{
-read_edf(file, .recording = file)
+read_edf(file, .recording = file, event_ch = NA)
 }
 \arguments{
 \item{file}{A edf/bdf file}
 
-\item{.recording}{Recording name (file name, by default). If set to NULL or NA, the patient name will be used.}
+\item{.recording}{Recording name (file name, by default). If set to NULL or
+NA, the patient name will be used.}
+
+\item{event_ch}{The name of the event channel to use. If not specified, the
+first non-signal channel in the file will be used.}
 }
 \value{
 An \code{eeg_lst} object.
@@ -28,8 +32,7 @@ If you have a case where this assumption is incorrect, please open an issue in \
 
 }
 \seealso{
-Other reading functions: 
-\code{\link{read_ft}()},
-\code{\link{read_vhdr}()}
+Other reading functions: \code{\link{read_ft}},
+  \code{\link{read_vhdr}}
 }
 \concept{reading functions}


### PR DESCRIPTION
I have a bunch of EDF+ files that include both a trigger channel and an EDF Annotations channel with the proper event names. However, since the annotations channel is always last per the EDF+ spec, eeguana drops it and uses the less-useful trigger channel for events instead.

To address this, I've modified `read_edf` to allow manually specifying which channel to use for events. I've tested it on my files and it works fine for me, let me know what you think!

Also, when I regenerated the docs to include the updated docstring it changed the formatting on a lot of the files, so I only included the updated Rd for the function I changed. Hopefully that doesn't cause any issues.